### PR TITLE
Modify: calc() 사용하여 메인페이지 높이 세부 조정

### DIFF
--- a/src/Pages/Main/Main.scss
+++ b/src/Pages/Main/Main.scss
@@ -72,3 +72,79 @@
 		}
 	}
 }
+
+@media screen and (max-width: 820px) {
+	.Main {
+		height: 100%;
+		overflow-y: visible;
+
+		article {
+			position: relative;
+			top: calc(-100vh);
+			z-index: 10;
+			background-color: #fff;
+
+			.videoWrapper {
+				position: absolute;
+				top: calc(100vh - 80px);
+				width: 100%;
+				height: 25%;
+				background-color: #fff;
+				display: flex;
+				justify-content: center;
+
+				.textWrapper {
+					position: absolute;
+					top: calc(55vh);
+					display: flex;
+					justify-content: center;
+					align-items: center;
+					flex-direction: column;
+					font-size: 14px;
+					font-weight: 500;
+
+					p {
+						margin-bottom: 10px;
+					}
+
+					h4 {
+						margin-bottom: 20px;
+						font-size: 1.8rem;
+					}
+
+					div {
+						padding: 10px 20px;
+						background-color: #fff;
+						font-size: 0.8rem;
+						cursor: pointer;
+					}
+				}
+			}
+			.centerContainer {
+				height: 340px;
+				width: 100%;
+				position: absolute;
+				bottom: 0;
+
+				.centerWrapper {
+					height: inherit;
+					display: flex;
+					justify-content: space-around;
+					align-items: center;
+				}
+
+				.logoBox {
+					width: 100%;
+					height: 50px;
+					border-top: 1px solid rgba(0, 0, 0, 0.05);
+					background-color: #fff;
+					img {
+						margin-top: 20px;
+						margin-left: 120px;
+						width: 70px;
+					}
+				}
+			}
+		}
+	}
+}

--- a/src/Pages/Main/Main.scss
+++ b/src/Pages/Main/Main.scss
@@ -5,13 +5,13 @@
 	article {
 		position: relative;
 		height: 400vh;
-		top: -90vh;
+		top: calc(-100vh + 90px);
 		z-index: 10;
 		background-color: #fff;
 
 		.videoWrapper {
 			position: absolute;
-			top: 90vh;
+			top: calc(100vh - 140px);
 			width: 100%;
 			height: 25%;
 			background-color: #fff;
@@ -20,7 +20,7 @@
 
 			.textWrapper {
 				position: absolute;
-				top: 80vh;
+				top: calc(100vh - 140px);
 				display: flex;
 				justify-content: center;
 				align-items: center;

--- a/src/config.js
+++ b/src/config.js
@@ -2,6 +2,8 @@ export const srcs = {
   video: {
     main:
       'http://www.chanel.com/videos/e_volume:mute/q_90,f_mp4,c_scale,w_2560,c_limit/FSH-1585840357798-hpmodedesktop.mp4',
+    mobile:
+      'https://www.chanel.com/videos/e_volume:mute/q_90,f_mp4,c_scale,w_828,c_limit/FSH-1585839895323-hpmodemobile.mp4',
   },
   img: {
     logo: {


### PR DESCRIPTION
>wecode PR message template 및 체크 리스트 입니다. 
아래 사항들을 전부 작성/체크 하시고 PR 해주세요!

## 수정 사항 간략한 한줄 요약
calc() 사용하여 메인페이지 높이 세부 조정
         
		 
## 수정 사항들 자세한 내용
- 기존의 `top: -85vh`에서 Nav 컴포넌트의 높이 만큼 정확하게 빼기 위하여 `top: calc(-100vh + 140px)`과 같은 형식으로 변경
- 높이 조정이 필요한 프로퍼티 모두 위와 같은 방식으로 변경
- mediaquery 추가하여 너비가 820px 이하일 때에는 높이 계산식 다르게 적용



## 체크 리스트 (아래 사항들이 전부 체크되어야만 merge가 됩니다!)
- [X] 필요한 test들을 완료하였고 기능이 제대로 실행되는지 확인 하였습니다.
- [X] Wecode의 코드 스타일 가이드에 맞추어 코드를 작성 하였습니다.
- [X] 제가 의도한 파일들과 수정 사항들만 커밋이 된 것을 확인 하였습니다.
- [X] 본 수정 사항들을 팀원들과 사전에 상의하였고 팀원들 모두 해당 PR에 대하여 알고 있습니다.
